### PR TITLE
feat(cors): update CORS configuration for production domains and add …

### DIFF
--- a/src/main/java/com/sameboat/backend/config/CorsConfig.java
+++ b/src/main/java/com/sameboat/backend/config/CorsConfig.java
@@ -1,12 +1,12 @@
 package com.sameboat.backend.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.cors.CorsConfigurationSource;
 
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -30,8 +30,9 @@ public class CorsConfig {
         }
         cfg.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
         cfg.setAllowedHeaders(List.of("*"));
-        cfg.setAllowCredentials(true); // we now send session cookie
+        cfg.setAllowCredentials(true); // allow cookie / credentialed requests
         cfg.setExposedHeaders(List.of("Set-Cookie"));
+        cfg.setMaxAge(Duration.ofHours(1));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", cfg);
         return source;

--- a/src/main/java/com/sameboat/backend/security/SecurityConfig.java
+++ b/src/main/java/com/sameboat/backend/security/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.access.AccessDeniedHandlerImpl;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.lang.NonNull;
 import org.springframework.security.core.AuthenticationException;
@@ -62,8 +63,10 @@ public class SecurityConfig {
                                                    @NonNull SessionAuthenticationFilter sessionAuthenticationFilter,
                                                    @NonNull AuthenticationEntryPoint jsonAuthEntryPoint) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/actuator/health", "/health", "/auth/login", "/auth/register", "/api/auth/login", "/api/auth/register").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(e -> e

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,10 +7,10 @@ spring:
 sameboat:
   cors:
     allowed-origins:
-      - https://app.sameboat.<tld>
-      - https://preview.sameboat.<tld>
+      - https://sameboatplatform.org
+      - https://app-sameboat.netlify.app/
   cookie:
     secure: true
-    domain: .sameboat.<tld>
+    domain: .sameboatplatform.org
   session:
     ttl-days: 14

--- a/src/test/java/com/sameboat/backend/config/CorsIntegrationTest.java
+++ b/src/test/java/com/sameboat/backend/config/CorsIntegrationTest.java
@@ -1,0 +1,50 @@
+package com.sameboat.backend.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies that CORS configuration allows the configured origin and does not reflect an unapproved origin.
+ * Uses the test profile but overrides the allowed origins with a production-like domain.
+ */
+@SpringBootTest(properties = {
+        "sameboat.cors.allowed-origins=https://app.sameboatplatform.org"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class CorsIntegrationTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Test
+    @DisplayName("Preflight request from allowed origin gets CORS allow headers")
+    void preflightAllowedOrigin() throws Exception {
+        mvc.perform(options("/health")
+                        .header("Origin", "https://app.sameboatplatform.org")
+                        .header("Access-Control-Request-Method", "GET")
+                        .header("Access-Control-Request-Headers", "Content-Type"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "https://app.sameboatplatform.org"))
+                .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+    }
+
+    @Test
+    @DisplayName("Preflight from disallowed origin gets 403 and no allow origin header")
+    void preflightDisallowedOrigin() throws Exception {
+        mvc.perform(options("/health")
+                        .header("Origin", "https://evil.example.com")
+                        .header("Access-Control-Request-Method", "GET"))
+                .andExpect(status().isForbidden())
+                .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+    }
+}


### PR DESCRIPTION
This pull request updates and strengthens the CORS configuration for the backend, improves security filter handling for preflight requests, and aligns production configuration with the new platform domain. It also adds integration tests to verify correct CORS behavior. The most important changes are grouped below:

**CORS Configuration Updates:**

* The CORS configuration now explicitly sets a `maxAge` for preflight requests and clarifies credential handling and exposed headers in `CorsConfig.java`. [[1]](diffhunk://#diff-ff5a9e5250b7ce6060c9253fc7ea8403dbf1302a095f2f422b7aac0e8b347189L3-R9) [[2]](diffhunk://#diff-ff5a9e5250b7ce6060c9253fc7ea8403dbf1302a095f2f422b7aac0e8b347189L33-R35)
* Production domains for allowed CORS origins and cookie domain are updated to reflect the new platform URLs in `application-prod.yml`.

**Security and Preflight Request Handling:**

* Security configuration now permits all HTTP OPTIONS requests, ensuring proper handling of CORS preflight requests and enabling `.cors()` support in the security filter chain. [[1]](diffhunk://#diff-d536f95a458fe0836fe6d46b9219087970ce2726cac4aef0d07b6db7d7068f81R17) [[2]](diffhunk://#diff-d536f95a458fe0836fe6d46b9219087970ce2726cac4aef0d07b6db7d7068f81R66-R69)

**Testing and Verification:**

* Added `CorsIntegrationTest.java` to verify that only configured origins are allowed and that unapproved origins are correctly denied, ensuring CORS settings work as intended.…integration tests