### PR TITLE
feat(cors): enhance CORS configuration with additional allowed origin…

### DIFF
--- a/src/main/java/com/sameboat/backend/config/CorsConfig.java
+++ b/src/main/java/com/sameboat/backend/config/CorsConfig.java
@@ -6,6 +6,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.cors.CorsConfigurationSource;
 
+import org.slf4j.Logger; import org.slf4j.LoggerFactory;
+
 import java.time.Duration;
 import java.util.List;
 
@@ -18,6 +20,7 @@ import java.util.List;
 public class CorsConfig {
 
     private final SameboatProperties props;
+    private static final Logger log = LoggerFactory.getLogger(CorsConfig.class);
 
     public CorsConfig(SameboatProperties props) { this.props = props; }
 
@@ -26,7 +29,12 @@ public class CorsConfig {
         CorsConfiguration cfg = new CorsConfiguration();
         for (String origin : props.getCors().getAllowedOrigins()) {
             String o = origin.trim();
-            if (!o.isEmpty()) cfg.addAllowedOrigin(o);
+            if (o.isEmpty()) continue;
+            if (o.contains("*")) {
+                cfg.addAllowedOriginPattern(o);
+            } else {
+                cfg.addAllowedOrigin(o);
+            }
         }
         cfg.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
         cfg.setAllowedHeaders(List.of("*"));
@@ -35,6 +43,7 @@ public class CorsConfig {
         cfg.setMaxAge(Duration.ofHours(1));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", cfg);
+        log.info("CORS allowed origins: {}", cfg.getAllowedOrigins().isEmpty() ? cfg.getAllowedOriginPatterns() : cfg.getAllowedOrigins());
         return source;
     }
 }

--- a/src/main/java/com/sameboat/backend/config/CorsConfig.java
+++ b/src/main/java/com/sameboat/backend/config/CorsConfig.java
@@ -44,7 +44,8 @@ public class CorsConfig {
         cfg.setMaxAge(Duration.ofHours(1));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", cfg);
-        log.info("CORS allowed origins: {}", cfg.getAllowedOrigins().isEmpty() ? cfg.getAllowedOriginPatterns() : cfg.getAllowedOrigins());
+        log.info("CORS allowed origins: {}", cfg.getAllowedOrigins());
+        log.info("CORS allowed origin patterns: {}", cfg.getAllowedOriginPatterns());
         return source;
     }
 }

--- a/src/main/java/com/sameboat/backend/config/CorsConfig.java
+++ b/src/main/java/com/sameboat/backend/config/CorsConfig.java
@@ -6,7 +6,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.cors.CorsConfigurationSource;
 
-import org.slf4j.Logger; import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.List;

--- a/src/main/java/com/sameboat/backend/security/SecurityConfig.java
+++ b/src/main/java/com/sameboat/backend/security/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
                 .csrf(org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers("/actuator/health", "/health", "/auth/login", "/auth/register", "/api/auth/login", "/api/auth/register").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/info", "/health", "/api/actuator/health", "/api/actuator/info", "/auth/login", "/auth/register", "/api/auth/login", "/api/auth/register").permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(e -> e
                         .authenticationEntryPoint(jsonAuthEntryPoint)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,11 +3,18 @@ spring:
   config:
     activate:
       on-profile: prod
-
+management:
+  endpoints:
+    web:
+      base-path: /api/actuator
+      exposure:
+        include: health,info
 sameboat:
   cors:
     allowed-origins:
       - https://sameboatplatform.org
+      - https://www.sameboatplatform.org
+      - https://app.sameboatplatform.org
       - https://app-sameboat.netlify.app
   cookie:
     secure: true

--- a/src/test/java/com/sameboat/backend/security/PublicActuatorEndpointsIntegrationTest.java
+++ b/src/test/java/com/sameboat/backend/security/PublicActuatorEndpointsIntegrationTest.java
@@ -1,0 +1,35 @@
+package com.sameboat.backend.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+/**
+ * Verifies that health/info actuator endpoints (with and without the /api base path) are public.
+ */
+@SpringBootTest(properties = {
+        "management.endpoints.web.base-path=/api/actuator"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PublicActuatorEndpointsIntegrationTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Test
+    @DisplayName("GET /api/actuator/health is public")
+    void apiActuatorHealth() throws Exception {
+        mvc.perform(get("/api/actuator/health"))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.status").value("UP"));
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,9 +6,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
   flyway:
     enabled: false
 logging:


### PR DESCRIPTION
This pull request improves CORS configuration, enhances actuator endpoint security, and updates environment settings for better deployment and testing. The main changes include more flexible CORS origin handling, expanded public actuator endpoints, configuration updates for production, and a new integration test to verify public access to health endpoints.

**CORS Configuration Improvements:**
* Added support for wildcard origins in CORS by using `addAllowedOriginPattern` when an origin contains a `*`, allowing more flexible origin matching. Also added logging for allowed origins and patterns in `CorsConfig.java`. [[1]](diffhunk://#diff-ff5a9e5250b7ce6060c9253fc7ea8403dbf1302a095f2f422b7aac0e8b347189R9-R10) [[2]](diffhunk://#diff-ff5a9e5250b7ce6060c9253fc7ea8403dbf1302a095f2f422b7aac0e8b347189R23) [[3]](diffhunk://#diff-ff5a9e5250b7ce6060c9253fc7ea8403dbf1302a095f2f422b7aac0e8b347189L29-R37) [[4]](diffhunk://#diff-ff5a9e5250b7ce6060c9253fc7ea8403dbf1302a095f2f422b7aac0e8b347189R46)

**Security and Endpoint Access:**
* Updated `SecurityConfig.java` to permit public access to both `/actuator/health`, `/actuator/info`, and their `/api/actuator` equivalents, ensuring these endpoints are accessible without authentication.

**Production Configuration Updates:**
* Modified `application-prod.yml` to expose only `health` and `info` actuator endpoints at `/api/actuator` and expanded the list of allowed CORS origins to include `www.sameboatplatform.org` and `app.sameboatplatform.org`.

**Testing Enhancements:**
* Added a new integration test `PublicActuatorEndpointsIntegrationTest.java` to verify that the `/api/actuator/health` endpoint is publicly accessible and returns the expected health status.

**Test Environment Cleanup:**
* Removed unused Hibernate dialect properties from `application-test.yml` for a cleaner test configuration.…s and logging, add integration test for actuator endpoints