### PR TITLE
chore: update Dockerfile to improve jar file copying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
 # syntax=docker/dockerfile:1
+
+# ---- build stage ----
 FROM maven:3.9-eclipse-temurin-21 AS build
 WORKDIR /app
 COPY . .
-# Ensure wrapper is executable in case host (e.g. Windows) dropped exec bit
 RUN chmod +x mvnw || true
 RUN ./mvnw -B -ntp -DskipTests package
 
+# ---- run stage ----
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 # non-root
 RUN addgroup --system app && adduser --system --ingroup app app
 USER app
-COPY --from=build /app/target/*-SNAPSHOT.jar app.jar
+# was: COPY --from=build /app/target/*-SNAPSHOT.jar app.jar
+COPY --from=build /app/target/*.jar /app/app.jar
 ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0"
 # Render provides $PORT; pass it through
 CMD ["sh","-c","java $JAVA_OPTS -Dserver.port=$PORT -jar app.jar"]


### PR DESCRIPTION
This pull request updates the `Dockerfile` to improve the build and deployment process for the application. The main changes involve clarifying the build and run stages and making the jar file copy command more robust.

**Dockerfile improvements:**

* Added explicit comments and separation for build and run stages to enhance readability and maintainability.
* Updated the jar file copy command to use `COPY --from=build /app/target/*.jar /app/app.jar`, ensuring it works for all jar files and not just those with `-SNAPSHOT` in their name.